### PR TITLE
Fix typo and add temporary await for syncronous transactions

### DIFF
--- a/web3/deploy_contract.js
+++ b/web3/deploy_contract.js
@@ -52,7 +52,8 @@ async function interact(newContractInstance, account, name) {
 async function run() {
   const account = await getCurrentAccount();
   const contract = await deployContract(account);
-  interact(contract, account, true);
+  // TODO: Remove await from first interact when mempool nonce resolved
+  await interact(contract, account, true);
   const blockNum = await interact(contract, account, false);
   console.log("block number: " + blockNum);
   // web3.eth.getBlock(parseInt(blockNum)).then(console.log);

--- a/web3/package.json
+++ b/web3/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "testDeploy": "node ./test_contract.js",
+    "testDeploy": "node ./deploy_contract.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
I forgot to change start script when I renamed file, and added await since the nonce in Ethermint cannot be pulled from the mempool (for now)