### PR TITLE
Update interaction transactions to finalize in same block

### DIFF
--- a/web3/deploy_contract.js
+++ b/web3/deploy_contract.js
@@ -1,12 +1,14 @@
 const Web3 = require("web3");
 const fs = require("fs");
 
-const web3 = new Web3(
-  new Web3.providers.HttpProvider("http://localhost:8545")
-);
+const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
 
-const contract = fs.readFileSync("../contracts/logsContract/build/Logger.bin").toString();
-const abiData = fs.readFileSync("../contracts/logsContract/build/Logger.abi").toString();
+const contract = fs
+  .readFileSync("../contracts/logsContract/build/Logger.bin")
+  .toString();
+const abiData = fs
+  .readFileSync("../contracts/logsContract/build/Logger.abi")
+  .toString();
 
 const ABI = JSON.parse(abiData);
 
@@ -28,22 +30,23 @@ async function deployContract(account) {
       gas: 470000,
       gasPrice: 20
     })
-    .then(function(newContractInstance) {
+    .then(function (newContractInstance) {
       console.log("Contract Address: ", newContractInstance.options.address);
       return newContractInstance;
     })
     .catch(err => console.log(err));
 }
 
-async function interact(newContractInstance, account, name) {
+async function interact(newContractInstance, account, name, nonce) {
   return newContractInstance.methods
     .emitTest(name)
     .send({
       from: account,
       gas: 470000,
-      gasPrice: 10
+      gasPrice: 10,
+      nonce: nonce
     })
-    .then(function(res) {
+    .then(function (res) {
       console.log("Tx", res.transactionIndex, ":", res.logsBloom);
       return res.blockNumber;
     });
@@ -51,29 +54,29 @@ async function interact(newContractInstance, account, name) {
 
 // This will get the block by block number and display it.  
 async function getBlockByNumber(blockNum) {
-    console.log("\n", "block number: " + blockNum);
-    return web3.eth.getBlock(parseInt(blockNum))
-    .then(console.log); 
+  console.log("\n", "block number: " + blockNum);
+  return web3.eth.getBlock(parseInt(blockNum))
+    .then(console.log);
 }
 
 async function run() {
   const account = await getCurrentAccount();
 
   const contract = await deployContract(account);
-  // TODO: Remove await from first interact when mempool nonce resolved
-  
-  const blockNumT = await interact(contract, account, true);
-  console.log("block number: " + blockNumT, "\n");
-  
-  const blockNumF = await interact(contract, account, false);
-  console.log("block number: " + blockNumF, "\n");
 
-  
-  // Displays event1 
-  await getBlockByNumber(blockNumT); 
-  
-  // Displays event2
-  await getBlockByNumber(blockNumF); 
+  const nonce = await web3.eth.getTransactionCount(account);
+
+  const tx1_fut = interact(contract, account, true, nonce);
+
+  // Sleep is just to ensure transaction ordering, no way I could find to wait for send confirmation
+  // without waiting for tx finalization with web3js. (This is not determistic unfortunately)
+  await new Promise(r => setTimeout(r, 100));
+
+  const blockNumF = await interact(contract, account, false, nonce + 1);
+  await tx1_fut;
+
+  // Displays finalized block
+  await getBlockByNumber(blockNumF);
 
   // web3.eth.getBlock(parseInt(blockNumT)).then(console.log);
 


### PR DESCRIPTION
- Only awaits the finalization of the second tx
  - thread sleep inbetween because there is no other clean way to ensure the transaction ordering on the node
